### PR TITLE
Add `MAX_AMOUNT` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twitter-images
 
-Fetches the last 1024 tweets of a given account, then prints original quality URLs for all image tweets. Useful for archiving image content from an art account without Twitter compression.
+Fetches the last tweets of a given account, then prints original quality URLs for all image tweets. Useful for archiving image content from an art account without Twitter compression.
 
 ## Usage
 
@@ -19,3 +19,4 @@ The tool is built to avoid interactive login and relies on the presence of a bun
 - `ACCESS_TOKEN` - Authentication access token for your user, for the project
 - `ACCESS_TOKEN_SECRET` - Access secret for your user
 - `TARGET_USERNAME` - The username of the account to fetch tweets from, such as `archillect`
+- `MAX_AMOUNT` - Optional, specifies the maximum amount of tweets to check (default is 1024).

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,10 @@ async fn main() -> Result<()> {
     let access_token = std::env::var("ACCESS_TOKEN")?;
     let access_token_secret = std::env::var("ACCESS_TOKEN_SECRET")?;
     let username = std::env::var("TARGET_USERNAME")?;
+    let page_size = std::env::var("MAX_AMOUNT")
+        .ok()
+        .and_then(|amount| amount.parse().ok())
+        .unwrap_or(1024);
 
     let consumer = KeyPair::new(consumer_key, consumer_secret);
     let access = KeyPair::new(access_token, access_token_secret);
@@ -20,7 +24,7 @@ async fn main() -> Result<()> {
 
     let user_id: UserID = username.into();
 
-    let timeline = tweet::user_timeline(user_id, false, false, &token).with_page_size(1024);
+    let timeline = tweet::user_timeline(user_id, false, false, &token).with_page_size(page_size);
     let (_, feed) = timeline.start().await?;
     print_urls(feed.iter());
 


### PR DESCRIPTION
Adds `MAX_AMOUNT` as a configuration - defaults to 1024.

I'm not sure about the name of the variable. This should probably be a CLI argument in the future.

Closes #2.