### PR TITLE
feat: Add CLI Options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +72,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -98,6 +124,21 @@ dependencies = [
  "serde",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -366,6 +407,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -673,6 +723,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +977,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1021,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1055,6 +1168,7 @@ version = "0.1.0"
 dependencies = [
  "color-eyre",
  "egg-mode",
+ "structopt",
  "tokio",
 ]
 
@@ -1086,6 +1200,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1234,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ readme = "README.md"
 color-eyre = { version = "0.5.11", default-features = false }
 egg-mode = { version = "0.16.0", features = ["rustls_webpki"], default-features = false }
 tokio = { version = "1.12.0", features = ["rt-multi-thread", "macros"] }
+structopt = "0.3.23"

--- a/README.md
+++ b/README.md
@@ -12,11 +12,31 @@ cd twitter-images
 cargo build --release
 ```
 
-The tool is built to avoid interactive login and relies on the presence of a bunch of environment variables that require a Twitter developer account and a project created on the account to obtain.
+The tool is built to avoid interactive login and relies on the presence of a bunch of environment variables/named arguments that require a Twitter developer account and a project created on the account to obtain.
 
-- `CONSUMER_KEY` - The consumer API key for the project
-- `CONSUMER_KEY_SECRET` - The consumer secret for the project
-- `ACCESS_TOKEN` - Authentication access token for your user, for the project
-- `ACCESS_TOKEN_SECRET` - Access secret for your user
-- `TARGET_USERNAME` - The username of the account to fetch tweets from, such as `archillect`
-- `MAX_AMOUNT` - Optional, specifies the maximum amount of tweets to check (default is 1024).
+- `CONSUMER_KEY` - The consumer API key for the project (`--consumer-secret`).
+- `CONSUMER_KEY_SECRET` - The consumer secret for the project (`--consumer-key-secret`).
+- `ACCESS_TOKEN` - Authentication access token for your user, for the project (`--access-token`).
+- `ACCESS_TOKEN_SECRET` - Access secret for your user (`--access-token-secret`).
+
+## Examples
+
+- **Basic Usage**
+
+    ```sh
+    twitter-images archillect
+    ```
+
+- **Set the maximum tweets to check**
+
+    ```sh
+    twitter-images archillect --max-amount 512
+    ```
+
+- **Full Options**
+
+    ```sh
+    twitter-images archillect --access-token <access-token> --access-token-secret <access-token-secret> --consumer-key <consumer-key> --consumer-key-secret <consumer-key-secret>
+    ```
+
+For more help run: `twitter-images -h`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,26 +5,50 @@ use egg_mode::tweet;
 use egg_mode::user::UserID;
 use egg_mode::KeyPair;
 use egg_mode::Token::Access;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(
+    rename_all = "kebab-case",
+    about = "Fetches the last tweets of a given account, then prints original quality URLs for all image tweets."
+)]
+struct CliOptions {
+    /// The Twitter username of the account to fetch images from.
+    username: String,
+
+    /// The maximum amount of tweets to check for images.
+    #[structopt(long, default_value = "1024")]
+    max_amount: i32,
+
+    /// The consumer API key for the project.
+    #[structopt(long, env)]
+    consumer_key: String,
+
+    /// The consumer secret for the project.
+    #[structopt(long, env)]
+    consumer_secret: String,
+
+    /// The access token for your user, for the project.
+    #[structopt(long, env)]
+    access_token: String,
+
+    /// The access token secret for your user.
+    #[structopt(long, env)]
+    access_token_secret: String,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let consumer_key = std::env::var("CONSUMER_KEY")?;
-    let consumer_secret = std::env::var("CONSUMER_KEY_SECRET")?;
-    let access_token = std::env::var("ACCESS_TOKEN")?;
-    let access_token_secret = std::env::var("ACCESS_TOKEN_SECRET")?;
-    let username = std::env::var("TARGET_USERNAME")?;
-    let page_size = std::env::var("MAX_AMOUNT")
-        .ok()
-        .and_then(|amount| amount.parse().ok())
-        .unwrap_or(1024);
+    let options: CliOptions = CliOptions::from_args();
 
-    let consumer = KeyPair::new(consumer_key, consumer_secret);
-    let access = KeyPair::new(access_token, access_token_secret);
+    let consumer = KeyPair::new(options.consumer_key, options.consumer_secret);
+    let access = KeyPair::new(options.access_token, options.access_token_secret);
     let token = Access { consumer, access };
 
-    let user_id: UserID = username.into();
+    let user_id: UserID = options.username.into();
 
-    let timeline = tweet::user_timeline(user_id, false, false, &token).with_page_size(page_size);
+    let timeline =
+        tweet::user_timeline(user_id, false, false, &token).with_page_size(options.max_amount);
     let (_, feed) = timeline.start().await?;
     print_urls(feed.iter());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use structopt::StructOpt;
 )]
 struct CliOptions {
     /// The Twitter username of the account to fetch images from.
-    #[structopt(env)]
+    #[structopt(env = "TARGET_USERNAME")]
     username: String,
 
     /// The maximum amount of tweets to check for images.

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,9 @@ struct CliOptions {
     #[structopt(long, env)]
     consumer_key: String,
 
-    /// The consumer secret for the project.
+    /// The consumer key secret for the project.
     #[structopt(long, env)]
-    consumer_secret: String,
+    consumer_key_secret: String,
 
     /// The access token for your user, for the project.
     #[structopt(long, env)]
@@ -42,7 +42,7 @@ struct CliOptions {
 async fn main() -> Result<()> {
     let options: CliOptions = CliOptions::from_args();
 
-    let consumer = KeyPair::new(options.consumer_key, options.consumer_secret);
+    let consumer = KeyPair::new(options.consumer_key, options.consumer_key_secret);
     let access = KeyPair::new(options.access_token, options.access_token_secret);
     let token = Access { consumer, access };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use structopt::StructOpt;
 )]
 struct CliOptions {
     /// The Twitter username of the account to fetch images from.
+    #[structopt(env)]
     username: String,
 
     /// The maximum amount of tweets to check for images.


### PR DESCRIPTION
The PR adds CLI options by using `structopt`.

Environment variables will still work after this PR.

The generated help page looks like this:

```
twitter-images 0.1.0
Fetches the last tweets of a given account, then prints original quality URLs for all image tweets.

USAGE:
    twitter-images.exe [OPTIONS] <username> --access-token <access-token> --access-token-secret <access-token-secret> --consumer-key <consumer-key> --consumer-key-secret <consumer-key-secret>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --access-token <access-token>
            The access token for your user, for the project [env: ACCESS_TOKEN=]

        --access-token-secret <access-token-secret>    The access token secret for your user [env: ACCESS_TOKEN_SECRET=]
        --consumer-key <consumer-key>                  The consumer API key for the project [env: CONSUMER_KEY=]
        --consumer-key-secret <consumer-key-secret>
            The consumer key secret for the project [env: CONSUMER_KEY_SECRET=]

        --max-amount <max-amount>                      The maximum amount of tweets to check for images [default: 1024]

ARGS:
    <username>    The Twitter username of the account to fetch images from [env: TARGET_USERNAME=]
```